### PR TITLE
Agrego flag -r

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ source venv/bin/activate
 Ahora instalar las dependencias dentro del `requirements.txt`:
 
 ```bash
-pip install requirements.txt
+pip install -r requirements.txt
 ```
 
 Luego ejecuta el programa y graba lo que quieras:


### PR DESCRIPTION
Hola @fedeotaran !
Faltaba el flag -r
y para instalar el paquete pyaudio en ubuntu tuve que hacerlo con pip.
`pip install pyaudio` , por si querés agregarlo también en el readme.

Saludos!